### PR TITLE
Remove/tweak redundant doors; improve integration with default doors

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -21,7 +21,7 @@ local function register_alias(name, convert_to)
 	minetest.register_alias(name .. "_b", convert_to .. "_b")
 end
 
-function ts_doors.register_door(item, description, texture, recipe)
+function ts_doors.register_door(item, description, texture, recipe, locked, windowed)
 	recipe = recipe or item
 	register_alias("doors:ts_door_" .. item:gsub(":", "_"), "ts_doors:door_" .. item:gsub(":", "_"))
 	register_alias("doors:ts_door_full_" .. item:gsub(":", "_"), "ts_doors:door_full_" .. item:gsub(":", "_"))
@@ -38,136 +38,148 @@ function ts_doors.register_door(item, description, texture, recipe)
 
 	trapdoor_groups = copytable(door_groups)
 
-	doors.register("ts_doors:door_" .. item:gsub(":", "_"), {
-		tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base.png^[noalpha^[makealpha:0,255,0", backface_culling = true }},
-		description = description .. " Door",
-		inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_inv.png^[noalpha^[makealpha:0,255,0",
-		groups = door_groups,
-		recipe = {
-			{recipe, recipe},
-			{recipe, recipe},
-			{recipe, recipe},
-		}
-	})
+	if locked == false or locked == nil then
+		if windowed == true or windowed == nil then
+			doors.register("ts_doors:door_" .. item:gsub(":", "_"), {
+				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base.png^[noalpha^[makealpha:0,255,0", backface_culling = true }},
+				description = description .. " Door",
+				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_inv.png^[noalpha^[makealpha:0,255,0",
+				groups = door_groups,
+				recipe = {
+					{recipe, recipe},
+					{recipe, recipe},
+					{recipe, recipe},
+				}
+			})
 
-	doors.register("ts_doors:door_full_" .. item:gsub(":", "_"), {
-		tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full.png^[noalpha", backface_culling = true }},
-		description = description .. " Door",
-		inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_inv.png^[noalpha^[makealpha:0,255,0",
-		groups = door_groups,
-		recipe = {
-			{recipe},
-			{"ts_doors:door_" .. item:gsub(":", "_")},
-		}
-	})
+			doors.register_trapdoor("ts_doors:trapdoor_" .. item:gsub(":", "_"), {
+				description = description .. " Trapdoor",
+				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
+				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
+				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
+				tile_side = texture .. "^[colorize:#fff:30",
+				groups = trapdoor_groups,
+			})
 
-	doors.register_trapdoor("ts_doors:trapdoor_" .. item:gsub(":", "_"), {
-		description = description .. " Trapdoor",
-		inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
-		wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
-		tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
-		tile_side = texture .. "^[colorize:#fff:30",
-		groups = trapdoor_groups,
-	})
+			minetest.register_craft({
+				output = "ts_doors:trapdoor_" .. item:gsub(":", "_"),
+				recipe = {
+					{recipe, recipe},
+					{recipe, recipe},
+				}
+			})
+		end
+		if windowed == false or windowed == nil then
+			doors.register("ts_doors:door_full_" .. item:gsub(":", "_"), {
+				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full.png^[noalpha", backface_culling = true }},
+				description = description .. " Door",
+				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_inv.png^[noalpha^[makealpha:0,255,0",
+				groups = door_groups,
+				recipe = {
+					{recipe},
+					{"ts_doors:door_" .. item:gsub(":", "_")},
+				}
+			})
 
-	doors.register_trapdoor("ts_doors:trapdoor_full_" .. item:gsub(":", "_"), {
-		description = description .. " Trapdoor",
-		inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
-		wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
-		tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
-		tile_side = texture .. "^[colorize:#fff:30",
-		groups = trapdoor_groups,
-	})
+			doors.register_trapdoor("ts_doors:trapdoor_full_" .. item:gsub(":", "_"), {
+				description = description .. " Trapdoor",
+				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
+				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
+				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
+				tile_side = texture .. "^[colorize:#fff:30",
+				groups = trapdoor_groups,
+			})
 
-	minetest.register_craft({
-		output = "ts_doors:trapdoor_" .. item:gsub(":", "_"),
-		recipe = {
-			{recipe, recipe},
-			{recipe, recipe},
-		}
-	})
-
-	minetest.register_craft({
-		output = "ts_doors:trapdoor_full_" .. item:gsub(":", "_"),
-		recipe = {
-			{recipe},
-			{"ts_doors:trapdoor_" .. item:gsub(":", "_")},
-		}
-	})
+			minetest.register_craft({
+				output = "ts_doors:trapdoor_full_" .. item:gsub(":", "_"),
+				recipe = {
+					{recipe},
+					{"ts_doors:trapdoor_" .. item:gsub(":", "_")},
+				}
+			})
+		end
+	end
 
 	door_groups.level = 2
 	trapdoor_groups.level = 2
 
-	doors.register("ts_doors:door_locked_" .. item:gsub(":", "_"), {
-		tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked.png^[noalpha^[makealpha:0,255,0", backface_culling = true }},
-		description = description .. " Locked Door",
-		inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked_inv.png^[noalpha^[makealpha:0,255,0",
-		protected = true,
-		groups = door_groups,
-		sound_open = "doors_steel_door_open",
-		sound_close = "doors_steel_door_close",
-		recipe = {
-			{recipe, recipe, ""},
-			{recipe, recipe, "default:steel_ingot"},
-			{recipe, recipe, ""},
-		}
-	})
+	if locked == true or locked == nil then
+		if windowed == true or windowed == nil then
+			doors.register("ts_doors:door_locked_" .. item:gsub(":", "_"), {
+				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked.png^[noalpha^[makealpha:0,255,0", backface_culling = true }},
+				description = description .. " Locked Door",
+				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked_inv.png^[noalpha^[makealpha:0,255,0",
+				protected = true,
+				groups = door_groups,
+				sound_open = "doors_steel_door_open",
+				sound_close = "doors_steel_door_close",
+				recipe = {
+					{recipe, recipe, ""},
+					{recipe, recipe, "default:steel_ingot"},
+					{recipe, recipe, ""},
+				}
+			})
 
-	doors.register("ts_doors:door_full_locked_" .. item:gsub(":", "_"), {
-		tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_locked.png^[noalpha", backface_culling = true }},
-		description = description .. " Locked Door",
-		inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_locked_inv.png^[noalpha^[makealpha:0,255,0",
-		protected = true,
-		groups = door_groups,
-		sound_open = "doors_steel_door_open",
-		sound_close = "doors_steel_door_close",
-		recipe = {
-			{recipe},
-			{"ts_doors:door_locked_" .. item:gsub(":", "_")},
-		}
-	})
+			doors.register_trapdoor("ts_doors:trapdoor_locked_" .. item:gsub(":", "_"), {
+				description = description .. " Locked Trapdoor",
+				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
+				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
+				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
+				tile_side = texture .. "^[colorize:#fff:30",
+				protected = true,
+				sounds = default.node_sound_stone_defaults(),
+				sound_open = "doors_steel_door_open",
+				sound_close = "doors_steel_door_close",
+				groups = trapdoor_groups
+			})
 
-	doors.register_trapdoor("ts_doors:trapdoor_locked_" .. item:gsub(":", "_"), {
-		description = description .. " Locked Trapdoor",
-		inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
-		wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
-		tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
-		tile_side = texture .. "^[colorize:#fff:30",
-		protected = true,
-		sounds = default.node_sound_stone_defaults(),
-		sound_open = "doors_steel_door_open",
-		sound_close = "doors_steel_door_close",
-		groups = trapdoor_groups
-	})
 
-	doors.register_trapdoor("ts_doors:trapdoor_full_locked_" .. item:gsub(":", "_"), {
-		description = description .. " Locked Trapdoor",
-		inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
-		wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
-		tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
-		tile_side = texture .. "^[colorize:#fff:30",
-		protected = true,
-		sounds = default.node_sound_stone_defaults(),
-		sound_open = "doors_steel_door_open",
-		sound_close = "doors_steel_door_close",
-		groups = trapdoor_groups
-	})
+			minetest.register_craft({
+				output = "ts_doors:trapdoor_locked_" .. item:gsub(":", "_"),
+				recipe = {
+					{"default:steel_ingot"},
+					{"ts_doors:trapdoor_" .. item:gsub(":", "_")},
+				}
+			})
 
-	minetest.register_craft({
-		output = "ts_doors:trapdoor_locked_" .. item:gsub(":", "_"),
-		recipe = {
-			{"default:steel_ingot"},
-			{"ts_doors:trapdoor_" .. item:gsub(":", "_")},
-		}
-	})
+		end
+		if windowed == false or windowed == nil then
+			doors.register("ts_doors:door_full_locked_" .. item:gsub(":", "_"), {
+				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_locked.png^[noalpha", backface_culling = true }},
+				description = description .. " Locked Door",
+				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_locked_inv.png^[noalpha^[makealpha:0,255,0",
+				protected = true,
+				groups = door_groups,
+				sound_open = "doors_steel_door_open",
+				sound_close = "doors_steel_door_close",
+				recipe = {
+					{recipe},
+					{"ts_doors:door_locked_" .. item:gsub(":", "_")},
+				}
+			})
 
-	minetest.register_craft({
-		output = "ts_doors:trapdoor_full_locked_" .. item:gsub(":", "_"),
-		recipe = {
-			{recipe},
-			{"ts_doors:trapdoor_locked_" .. item:gsub(":", "_")},
-		}
-	})
+			doors.register_trapdoor("ts_doors:trapdoor_full_locked_" .. item:gsub(":", "_"), {
+				description = description .. " Locked Trapdoor",
+				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
+				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
+				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
+				tile_side = texture .. "^[colorize:#fff:30",
+				protected = true,
+				sounds = default.node_sound_stone_defaults(),
+				sound_open = "doors_steel_door_open",
+				sound_close = "doors_steel_door_close",
+				groups = trapdoor_groups
+			})
+
+			minetest.register_craft({
+				output = "ts_doors:trapdoor_full_locked_" .. item:gsub(":", "_"),
+				recipe = {
+					{recipe},
+					{"ts_doors:trapdoor_locked_" .. item:gsub(":", "_")},
+				}
+			})
+		end
+	end
 end
 
 ts_doors.register_door("default:aspen_wood" , "Aspen"      , "default_aspen_wood.png" )
@@ -194,7 +206,6 @@ ts_doors.register_door("default:bronzeblock" , "Bronze" , "default_bronze_block.
 ts_doors.register_door("default:copperblock" , "Copper" , "default_copper_block.png" , "default:copper_ingot" )
 ts_doors.register_door("default:diamondblock", "Diamond", "default_diamond_block.png", "default:diamond"      )
 ts_doors.register_door("default:goldblock"   , "Gold"   , "default_gold_block.png"   , "default:gold_ingot"   )
-ts_doors.register_door("default:steelblock"  , "Steel"  , minetest.registered_nodes["default:steelblock"].tiles[1], "default:steel_ingot")
 
 if minetest.get_modpath("moreores") then
 	ts_doors.register_door("moreores:mithril_block", "Mithril", "moreores_mithril_block.png", "moreores:mithril_ingot")
@@ -214,3 +225,64 @@ if minetest.get_modpath("technic") then
 	ts_doors.register_door("technic:concrete"                , "Concrete"                , "technic_concrete_block.png"                )
 	ts_doors.register_door("technic:blast_resistant_concrete", "Blast Resistant Concrete", "technic_blast_resistant_concrete_block.png")
 end
+
+-- Overwrite steel door and wooden door from Minetest Game
+-- TODO: Remove craft of doors:door_steel with clear_craft
+
+ts_doors.register_door("default:steelblock"  , "Steel"  , minetest.registered_nodes["default:steelblock"].tiles[1], "default:steel_ingot", nil, false)
+ts_doors.register_door("default:steelblock"  , "Steel"  , minetest.registered_nodes["default:steelblock"].tiles[1], "default:steel_ingot", false, true)
+
+-- Use default steel door node for “locked steel door”
+minetest.register_craft({ output = "doors:door_steel", recipe = {
+	{ "default:steel_ingot", "default:steel_ingot", "" },
+	{ "default:steel_ingot", "default:steel_ingot", "default:steel_ingot" },
+	{ "default:steel_ingot", "default:steel_ingot", "" }, } })
+minetest.register_craft({ output = "ts_doors:door_full_locked_default_steelblock", recipe = {
+	{ "default:steel_ingot" },
+	{ "doors:door_steel" }, } })
+minetest.register_craft({ output = "doors:trapdoor_steel", recipe = {
+	{ "ts_doors:trapdoor_default_steelblock" },
+	{ "default:steel_ingot" }, } })
+minetest.register_craft({ output = "ts_doors:trapdoor_full_locked_default_steelblock", recipe = {
+	{ "doors:trapdoor_steel" },
+	{ "default:steel_ingot" }, } })
+
+local texture = minetest.registered_nodes["default:steelblock"].tiles[1]
+minetest.override_item("doors:door_steel", {
+	inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked_inv.png^[noalpha^[makealpha:0,255,0",
+	description = "Locked Steel Door",
+})
+
+local tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0"
+local tile_side = texture .. "^[colorize:#fff:30"
+minetest.override_item("doors:trapdoor_steel", {
+	inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
+	wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
+	description = "Locked Steel Trapdoor",
+	tiles = { tile_front, tile_front, tile_side, tile_side, tile_side, tile_side },
+})
+
+minetest.override_item("doors:trapdoor_steel_open", {
+	tiles = { tile_side, tile_side, tile_side, tile_side, tile_front, tile_front },
+})
+
+minetest.override_item("doors:door_steel_a", {
+	tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked.png^[noalpha^[makealpha:0,255,0", backface_culling = true }},
+})
+minetest.override_item("doors:door_steel_b", {
+	tiles = minetest.registered_items["doors:door_steel_a"].tiles,
+})
+
+-- Overwrite default wooden doors
+-- TODO: Custom textures
+minetest.override_item("doors:door_wood", {
+	description = "Mixed Wood Door",
+})
+minetest.override_item("doors:trapdoor", {
+	description = "Mixed Wood Trapdoor",
+})
+
+-- Legacy support
+register_alias("ts_doors:door_locked_default_steelblock", "doors:door_steel")
+minetest.register_alias("ts_doors:trapdoor_locked_default_steelblock", "doors:trapdoor_steel")
+minetest.register_alias("ts_doors:trapdoor_locked_default_steelblock_open", "doors:trapdoor_steel_open")

--- a/init.lua
+++ b/init.lua
@@ -42,7 +42,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 		if windowed == true or windowed == nil then
 			doors.register("ts_doors:door_" .. item:gsub(":", "_"), {
 				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base.png^[noalpha^[makealpha:0,255,0", backface_culling = true }},
-				description = description .. " Door",
+				description = "Windowed " .. description .. " Door",
 				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_inv.png^[noalpha^[makealpha:0,255,0",
 				groups = door_groups,
 				recipe = {
@@ -53,7 +53,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 			})
 
 			doors.register_trapdoor("ts_doors:trapdoor_" .. item:gsub(":", "_"), {
-				description = description .. " Trapdoor",
+				description = "Windowed " .. description .. " Trapdoor",
 				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
 				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
 				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor.png^[noalpha^[makealpha:0,255,0",
@@ -72,7 +72,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 		if windowed == false or windowed == nil then
 			doors.register("ts_doors:door_full_" .. item:gsub(":", "_"), {
 				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full.png^[noalpha", backface_culling = true }},
-				description = description .. " Door",
+				description = "Solid " .. description .. " Door",
 				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_inv.png^[noalpha^[makealpha:0,255,0",
 				groups = door_groups,
 				recipe = {
@@ -82,7 +82,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 			})
 
 			doors.register_trapdoor("ts_doors:trapdoor_full_" .. item:gsub(":", "_"), {
-				description = description .. " Trapdoor",
+				description = "Solid " .. description .. " Trapdoor",
 				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
 				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
 				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full.png^[noalpha",
@@ -107,7 +107,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 		if windowed == true or windowed == nil then
 			doors.register("ts_doors:door_locked_" .. item:gsub(":", "_"), {
 				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked.png^[noalpha^[makealpha:0,255,0", backface_culling = true }},
-				description = description .. " Locked Door",
+				description = "Locked Windowed " .. description .. " Door",
 				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked_inv.png^[noalpha^[makealpha:0,255,0",
 				protected = true,
 				groups = door_groups,
@@ -121,7 +121,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 			})
 
 			doors.register_trapdoor("ts_doors:trapdoor_locked_" .. item:gsub(":", "_"), {
-				description = description .. " Locked Trapdoor",
+				description = "Locked Windowed " .. description .. " Trapdoor",
 				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
 				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
 				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
@@ -146,7 +146,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 		if windowed == false or windowed == nil then
 			doors.register("ts_doors:door_full_locked_" .. item:gsub(":", "_"), {
 				tiles = {{ name = "[combine:32x38:0,0=" .. texture .. ":0,16=" .. texture .. ":0,32=" .. texture .. ":16,0=" .. texture .. ":16,16=" .. texture .. ":16,32=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_locked.png^[noalpha", backface_culling = true }},
-				description = description .. " Locked Door",
+				description = "Locked Solid " .. description .. " Door",
 				inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_full_locked_inv.png^[noalpha^[makealpha:0,255,0",
 				protected = true,
 				groups = door_groups,
@@ -159,7 +159,7 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 			})
 
 			doors.register_trapdoor("ts_doors:trapdoor_full_locked_" .. item:gsub(":", "_"), {
-				description = description .. " Locked Trapdoor",
+				description = "Locked Solid " .. description .. " Trapdoor",
 				inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
 				wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
 				tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_full_locked.png^[noalpha",
@@ -244,7 +244,7 @@ minetest.register_craft({ output = "doors:trapdoor_steel", recipe = {
 local texture = minetest.registered_nodes["default:steelblock"].tiles[1]
 minetest.override_item("doors:door_steel", {
 	inventory_image = "[combine:32x32:0,8=" .. texture .. ":16,8=" .. texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_locked_inv.png^[noalpha^[makealpha:0,255,0",
-	description = "Locked Steel Door",
+	description = "Locked Windowed Steel Door",
 })
 
 local tile_front = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0"
@@ -252,7 +252,7 @@ local tile_side = texture .. "^[colorize:#fff:30"
 minetest.override_item("doors:trapdoor_steel", {
 	inventory_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
 	wield_image = texture .. "^[transformR90^[colorize:#fff:30^ts_doors_base_trapdoor_locked.png^[noalpha^[makealpha:0,255,0",
-	description = "Locked Steel Trapdoor",
+	description = "Locked Windowed Steel Trapdoor",
 	tiles = { tile_front, tile_front, tile_side, tile_side, tile_side, tile_side },
 })
 
@@ -270,10 +270,10 @@ minetest.override_item("doors:door_steel_b", {
 -- Overwrite default wooden doors
 -- TODO: Custom textures
 minetest.override_item("doors:door_wood", {
-	description = "Mixed Wood Door",
+	description = "Windowed Mixed Wood Door",
 })
 minetest.override_item("doors:trapdoor", {
-	description = "Mixed Wood Trapdoor",
+	description = "Windowed Mixed Wood Trapdoor",
 })
 
 -- Legacy support

--- a/init.lua
+++ b/init.lua
@@ -227,7 +227,14 @@ if minetest.get_modpath("technic") then
 end
 
 -- Overwrite steel door and wooden door from Minetest Game
--- TODO: Remove craft of doors:door_steel with clear_craft
+
+-- Code does not work in Minetest 0.4.14, so we check first
+-- TODO: Remove this check when Minetest with minetest.clear_craft is officially released
+if minetest.clear_craft ~= nil then
+	-- Remove the default recipes for the default steel doors since we add our own recipes
+	minetest.clear_craft({output = "doors:door_steel"})
+	minetest.clear_craft({output = "doors:trapdoor_steel"})
+end
 
 ts_doors.register_door("default:steelblock"  , "Steel"  , minetest.registered_nodes["default:steelblock"].tiles[1], "default:steel_ingot", nil, false)
 ts_doors.register_door("default:steelblock"  , "Steel"  , minetest.registered_nodes["default:steelblock"].tiles[1], "default:steel_ingot", false, true)

--- a/init.lua
+++ b/init.lua
@@ -137,8 +137,8 @@ function ts_doors.register_door(item, description, texture, recipe, locked, wind
 			minetest.register_craft({
 				output = "ts_doors:trapdoor_locked_" .. item:gsub(":", "_"),
 				recipe = {
-					{"default:steel_ingot"},
 					{"ts_doors:trapdoor_" .. item:gsub(":", "_")},
+					{"default:steel_ingot"},
 				}
 			})
 
@@ -237,14 +237,8 @@ minetest.register_craft({ output = "doors:door_steel", recipe = {
 	{ "default:steel_ingot", "default:steel_ingot", "" },
 	{ "default:steel_ingot", "default:steel_ingot", "default:steel_ingot" },
 	{ "default:steel_ingot", "default:steel_ingot", "" }, } })
-minetest.register_craft({ output = "ts_doors:door_full_locked_default_steelblock", recipe = {
-	{ "default:steel_ingot" },
-	{ "doors:door_steel" }, } })
 minetest.register_craft({ output = "doors:trapdoor_steel", recipe = {
 	{ "ts_doors:trapdoor_default_steelblock" },
-	{ "default:steel_ingot" }, } })
-minetest.register_craft({ output = "ts_doors:trapdoor_full_locked_default_steelblock", recipe = {
-	{ "doors:trapdoor_steel" },
 	{ "default:steel_ingot" }, } })
 
 local texture = minetest.registered_nodes["default:steelblock"].tiles[1]


### PR DESCRIPTION
One problem with this mod was that it redundantly adds two steel doors which already exist in Minetest Game: The windowed locked steel door and the windowed locked steel trap door.

What this PR does in detail:
- Remove `ts_doors:door_locked_default_steelblock`
- Remove `ts_doors:door_locked_default_steelblock`
- Overwrite `doors:door_steel` and `doors:trapdoor_steel` to use new textures and names
- Use aliases for the removed doors
- Remove (post-0.4.14 only) and change crafting recipes to fix recipe collisions caused by this and to “integrate” the default doors into this mod (into the set of crafting recipes)
- For better item recognition, all doors now have unique names
- Default wooden door and trapdoors are intentionally kept because they are crafted by `group:wood`. They are only renamed for now

Everything in this PR is (hopefully) fully backwards-compatible. From the player perspective, the default steel doors now look they “belong” to the set of `ts_doors` and also neatly fit into the set of crafting recipes.
