### PR TITLE
added doors to the door group

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -107,7 +107,7 @@ function ts_doors.register_door(item, description, texture, sounds, recipe)
 	register_alias("doors:ts_door_full_locked_" .. item:gsub(":", "_"), "ts_doors:door_full_locked_" .. item:gsub(":", "_"))
 
 	local groups = minetest.registered_nodes[item].groups
-	local door_groups = {}
+	local door_groups = {door=1}
 	for k, v in pairs(groups) do
 		if k ~= "wood" then
 			door_groups[k] = v


### PR DESCRIPTION
Tthis PR is for the trapdoors. For the doors the group is set in doors.register()
doors.register_trapdoor() does not set it automatically but it is usually set during definition. See [minetest_game/doors#L667](https://github.com/minetest/minetest_game/blob/master/mods/doors/init.lua#L667) as example. I need the attribute to be able to show the trapdoors as "Shaped" in smart_inventory beside the default trapdoors.