### PR TITLE
Report bugs as errors

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -87,7 +87,7 @@ end
 
 function ts_doors.register_door(item, description, texture, sounds, recipe)
 	if not minetest.registered_nodes[item] then
-		minetest.log("[ts_doors] bug found: "..item.." is not a registered node. Cannot create doors")
+		minetest.log("error", "[ts_doors] Bug found: "..item.." is not a registered node. Can not create doors.")
 		return
 	end
 	if not sounds then


### PR DESCRIPTION
When ts_doors [can't create a door](https://github.com/minetest-mods/ts_doors/blob/53f062ab720c0ac046edad3f019497b5952f69e1/init.lua#L90) it logs that with log level type "none" (because no type is specified, so [fallback is used](https://github.com/minetest/minetest/blob/master/doc/lua_api.md#logging))
In my opinion we should set the log level to "error", which is in line with calling it "a bug".